### PR TITLE
Move secrets to environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+FLASK_SECRET_KEY=your_secret_key
+MONGO_URI=mongodb://username:password@host/db

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Record App
+
+This Flask application reads data from MongoDB and allows administrators to edit
+records through a web interface. Finalised data are stored in the `check_done`
+collection.
+
+## Configuration
+
+Secrets are provided via environment variables:
+
+- `MONGO_URI` – MongoDB connection string
+- `FLASK_SECRET_KEY` – secret key used for Flask sessions
+
+You can create a `.env` file based on `.env.example` and load it in your
+environment before running the application.
+Start the app with:
+
+```bash
+python app.py
+```

--- a/app.py
+++ b/app.py
@@ -2,12 +2,21 @@ from flask import Flask, request, render_template, redirect, session, url_for
 from pymongo import MongoClient
 from bson import ObjectId
 from datetime import datetime
+import os
 
 app = Flask(__name__)
-app.secret_key = "super-secret-key"  # 用于启用 session
+# 从环境变量读取 Flask 会话密钥，未设置则抛出错误
+secret_key = os.getenv("FLASK_SECRET_KEY")
+if not secret_key:
+    raise RuntimeError("FLASK_SECRET_KEY environment variable not set")
+app.secret_key = secret_key
 
 # === MongoDB 设置 ===
-client = MongoClient("mongodb+srv://rrriotacc:B0SdDj36GLxIkHuZ@lizard.fyju0pz.mongodb.net/")
+# 连接字符串从环境变量读取，避免在代码中暴露凭据
+mongo_uri = os.getenv("MONGO_URI")
+if not mongo_uri:
+    raise RuntimeError("MONGO_URI environment variable not set")
+client = MongoClient(mongo_uri)
 db = client["chillmartTemp"]
 qa_collection = db["qa_bot"]
 done_collection = db["check_done"]

--- a/skip.py
+++ b/skip.py
@@ -1,7 +1,11 @@
 from pymongo import MongoClient
+import os
 
 # ===== MongoDB 连接设置 =====
-client = MongoClient("mongodb+srv://rrriotacc:B0SdDj36GLxIkHuZ@lizard.fyju0pz.mongodb.net/")
+mongo_uri = os.getenv("MONGO_URI")
+if not mongo_uri:
+    raise RuntimeError("MONGO_URI environment variable not set")
+client = MongoClient(mongo_uri)
 db = client["chillmartTemp"]
 qa_collection = db["qa_bot"]
 


### PR DESCRIPTION
## Summary
- avoid storing credentials in code
- add `.env.example` and new README instructions
- use `MONGO_URI` and `FLASK_SECRET_KEY` variables in `app.py` and `skip.py`

## Testing
- `python3 -m py_compile app.py skip.py`

------
https://chatgpt.com/codex/tasks/task_e_68681f3482ec8327a9d25568bf76a53f